### PR TITLE
fixing copy term button

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: 2.3.22
           bundler-cache: true
 
       - run: bundle exec rspec

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -33,7 +33,7 @@
         var textToCopy = '';
         var elmsToCopy = [];
 
-        elmsToCopy.push(tgtElement.getElementsByTagName('h3')[0]);
+        elmsToCopy.push(tgtElement.getElementsByClassName('heading')[0]);
         elmsToCopy.push(tgtElement.getElementsByClassName('definition')[0]);
         elmsToCopy.push(tgtElement.getElementsByClassName('notes')[0]);
         elmsToCopy.push(tgtElement.getElementsByClassName('examples')[0]);


### PR DESCRIPTION
Fixing copy to clipboard button.

<img width="1680" alt="Screenshot 2022-10-07 at 12 59 42 PM" src="https://user-images.githubusercontent.com/5301572/194505529-ec06b107-b183-4667-86ad-64743b6eeaea.png">


closes geolexica/isotc211.geolexica.org#175