### PR TITLE
allowing authoritativeSource in yaml files

### DIFF
--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -71,10 +71,20 @@ module Jekyll
 
           next unless concept[lang]
 
+          normalize_sources(concept[lang])
           concept['term'] = concept[lang]['terms'].first['designation'] if lang == 'eng'
         end
 
         concept
+      end
+
+      def normalize_sources(concept)
+        authoritative_sources = concept.delete('authoritativeSource') || []
+        concept['sources'] ||= []
+
+        authoritative_sources.each do |authoritative_source|
+          concept['sources'] << authoritative_source.merge({ 'type' => 'authoritative' })
+        end
       end
 
       # Does nothing, but some sites may replace this method.

--- a/spec/concept_fixtures/paneron_glossary/concept/055c7785-e3c2-4df0-bcbc-83c1314864af.yaml
+++ b/spec/concept_fixtures/paneron_glossary/concept/055c7785-e3c2-4df0-bcbc-83c1314864af.yaml
@@ -1,0 +1,7 @@
+id: 055c7785-e3c2-4df0-bcbc-83c1314864af
+data:
+  identifier: SPP
+  localizedConcepts:
+    eng: 04e539b2-4557-4d05-a603-9881ed6951c6
+status: valid
+dateAccepted: 2023-07-26T09:20:44.609Z

--- a/spec/concept_fixtures/paneron_glossary/localized-concept/04e539b2-4557-4d05-a603-9881ed6951c6.yaml
+++ b/spec/concept_fixtures/paneron_glossary/localized-concept/04e539b2-4557-4d05-a603-9881ed6951c6.yaml
@@ -1,0 +1,15 @@
+id: 04e539b2-4557-4d05-a603-9881ed6951c6
+data:
+  terms:
+    - designation: SPP
+      type: expression
+      normative_status: preferred
+  language_code: eng
+  definition:
+    - content: Standards-related Publications and Projects
+  notes: []
+  examples: []
+  authoritativeSource:
+    - ref: MSF
+status: valid
+dateAccepted: 2023-06-22T19:08:31.601Z

--- a/spec/unit/jekyll/geolexica/glossary_spec.rb
+++ b/spec/unit/jekyll/geolexica/glossary_spec.rb
@@ -36,6 +36,50 @@ RSpec.describe ::Jekyll::Geolexica::Glossary do
     end
   end
 
+  context "Glossarist V2 concepts" do
+    describe "#load_concept" do
+      let(:load_concept) { subject.send(:load_concept, file_path) }
+      let(:file_path) { fixture_path("paneron_glossary/concept/055c7785-e3c2-4df0-bcbc-83c1314864af.yaml") }
+
+      let(:expected_data) do
+        {
+          "id" => "055c7785-e3c2-4df0-bcbc-83c1314864af",
+          "termid" => "SPP",
+          "eng" => {
+            "terms" => [{
+              "designation" => "SPP",
+              "type" => "expression",
+              "normative_status" => "preferred"
+            }],
+            "language_code" => "eng",
+            "definition" => [{
+              "content" => "Standards-related Publications and Projects"
+            }],
+            "notes" => [],
+            "examples" => [],
+            "sources" => [
+              { "type" => "authoritative", "ref" => "MSF" }
+            ]
+          }
+        }
+      end
+
+      before(:each) do
+        allow(subject).to receive(:glossary_format).and_return("paneron")
+        allow(subject).to receive(:localized_concepts_path).and_return(fixture_path("paneron_glossary/localized-concept"))
+      end
+
+      it "should change data count" do
+        expect { load_concept }.to change { subject.count }.from(0).to(1)
+      end
+
+      it "should load data" do
+        load_concept
+        expect(subject["SPP"].data).to include(expected_data)
+      end
+    end
+  end
+
   def add_concepts(*concept_hashes)
     concepts = concept_hashes.map { |h| described_class::Concept.new(h) }
     concepts.each { |c| instance.store c }


### PR DESCRIPTION
Accept `authoritativeSource` as a field name for authoritative sources.

closes #12 