### PR TITLE
erroneous character fix

### DIFF
--- a/_includes/localized-concept.html
+++ b/_includes/localized-concept.html
@@ -42,7 +42,7 @@
     {% if localized_term.definition %}
       {% for definition in localized_term.definition %}
         <p class="definition localized">
-          {%- if localized_term.domain != blank -%}
+          {%- if localized_term.domain -%}
             &lt;{{ localized_term.domain | escape }}&gt;&nbsp;
           {%- endif -%}
           {{ definition.content | escape | resolve_reference_to_links }}


### PR DESCRIPTION
fixing erroneous characters "<>" appearing in all definitions across all languages

closes geolexica/isotc211.geolexica.org#200