### PR TITLE
fix: pin plurimath >= 0.10.7 for mml compatibility (unblock CI)

### DIFF
--- a/jekyll-geolexica.gemspec
+++ b/jekyll-geolexica.gemspec
@@ -44,7 +44,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", ">= 3.8.5", "< 4.3", "!= 4.1.0"
 
   spec.add_runtime_dependency "jekyll-asciidoc"
-  spec.add_runtime_dependency "plurimath"
+  # plurimath < 0.10.7 requires "mml/configuration", which mml >= 2.2 removed,
+  # so an unpinned plurimath resolves to a combo that fails to load. 0.10.7+
+  # requires "mml" and pins "mml ~> 2.3.6".
+  spec.add_runtime_dependency "plurimath", ">= 0.10.7"
   spec.add_runtime_dependency "relaton"
   spec.add_runtime_dependency "unitsml"
 


### PR DESCRIPTION
## Problem

CI (`Test` workflow) fails at **spec_helper load time**, before any example runs:

```
Failure/Error: require "plurimath"
LoadError: cannot load such file -- mml/configuration
0 examples, 0 failures, 1 error occurred outside of examples
```

This is **pre-existing** and independent of any feature work — the last green `Test` run on `main` was Oct 2025, before the offending gem versions shipped. `Gemfile.lock` is gitignored, so CI resolves the latest gems on every run.

## Root cause

- `plurimath` was declared with **no version constraint**, so bundler resolves `plurimath 0.10.0`.
- `plurimath 0.10.0/lib/plurimath.rb:2` does `require "mml/configuration"`.
- `mml/configuration.rb` was removed in **mml >= 2.2** (present up to 2.1.0). The resolved `mml 2.3.7` no longer provides it → `LoadError`, aborting the whole suite.

## Fix

```ruby
spec.add_runtime_dependency "plurimath", ">= 0.10.7"
```

`plurimath 0.10.7+` requires `"mml"` (not `"mml/configuration"`) and pins `mml ~> 2.3.6`.

## Verification (local, bundler 2.3.27)

- Resolution now selects **plurimath 0.11.0 + mml 2.3.7 + omml 0.2.1 + lutaml-model 0.8.16** — no conflict.
- `require "plurimath"` loads cleanly (the exact CI failure is gone).
- `bundle exec rspec` goes from `0 examples, 1 error outside examples` → **59 examples running**.

The remaining example failures are pre-existing and out of scope for this PR (Ruby-3.4-local `OpenStruct` `NameError`s that don't affect CI's Ruby 3.0/3.1, plus separate glossarist `to_yaml_hash` fixture debt).